### PR TITLE
Use the maximum size of arrays specified in limits.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ named `csaf-0.json` through `csaf-99.json`:
 go run cmd/fakedoc/main.go --template template.toml -n 100 -o 'csaf-{{$}}.json'
 ```
 
+To generate large documents, one can use the something like this:
+
+``` shell
+go run cmd/fakedoc/main.go -o random-csaf.json -l limits.json --force-max-size
+```
+
+With the `-l limits.json` option, fakedoc loads information about the
+maximum lengths of arrays, strings and URIs from the `limits.json` file.
+If loaded the maximum lenghts of arrays are taken from this file (it's
+only implemented for arrays so far). By default these maximum values are
+multiplied by 0.00001 to avoid generating exceedingly large files. This
+factor can be set with the `--size` option. With the `--force-max-size`
+option, fakedoc tries to make arrays as large as their maximum length.
+
+How big the files will actually be depends not only on the length of the
+arrays but also on which parts of the document are actually generated. 
 
 
 ## License

--- a/cmd/fakedoc/main.go
+++ b/cmd/fakedoc/main.go
@@ -55,6 +55,11 @@ Guidance on the Size of CSAF Documents.
 	sizeFactorDocumentation = `
 Factor by which to multiply the maxima given in the limits file.
 `
+
+	forceMaxSizeDocumentation = `
+Try to force size of arrays to their maxiumum as defined in the limits
+file and modified by the size factor.
+`
 )
 
 func check(err error) {
@@ -68,6 +73,7 @@ func main() {
 		templatefile string
 		limitsfile   string
 		sizeFactor   float64
+		forceMaxSize bool
 		seed         string
 		outputfile   string
 		numOutputs   int
@@ -77,6 +83,7 @@ func main() {
 	flag.StringVar(&templatefile, "template", "", "template file")
 	flag.StringVar(&limitsfile, "l", "", limitsDocumentation)
 	flag.Float64Var(&sizeFactor, "size", 0.00001, sizeFactorDocumentation)
+	flag.BoolVar(&forceMaxSize, "force-max-size", false, forceMaxSizeDocumentation)
 	flag.StringVar(&seed, "seed", "", seedDocumentation)
 	flag.StringVar(&outputfile, "o", "", outputDocumentation)
 	flag.IntVar(&numOutputs, "n", 1, numOutputDocumentation)
@@ -99,7 +106,7 @@ func main() {
 	check(generate(
 		templatefile, rng,
 		outputfile, limitsfile,
-		sizeFactor,
+		sizeFactor, forceMaxSize,
 		numOutputs, formatted))
 }
 
@@ -107,7 +114,7 @@ func generate(
 	templatefile string,
 	rng *rand.Rand,
 	outputfile, limitsfile string,
-	sizeFactor float64,
+	sizeFactor float64, forceMaxSize bool,
 	numOutputs int,
 	formatted bool,
 ) error {
@@ -131,7 +138,7 @@ func generate(
 		}
 	}
 
-	generator := fakedoc.NewGenerator(templ, limits, sizeFactor, rng)
+	generator := fakedoc.NewGenerator(templ, limits, sizeFactor, forceMaxSize, rng)
 
 	if numOutputs == 1 {
 		return generateToFile(generator, outputfile, formatted)

--- a/cmd/fakedoc/main.go
+++ b/cmd/fakedoc/main.go
@@ -51,6 +51,10 @@ Output JSON should be formatted.
 	limitsDocumentation = `
 Guidance on the Size of CSAF Documents.
 `
+
+	sizeFactorDocumentation = `
+Factor by which to multiply the maxima given in the limits file.
+`
 )
 
 func check(err error) {
@@ -63,6 +67,7 @@ func main() {
 	var (
 		templatefile string
 		limitsfile   string
+		sizeFactor   float64
 		seed         string
 		outputfile   string
 		numOutputs   int
@@ -71,6 +76,7 @@ func main() {
 
 	flag.StringVar(&templatefile, "template", "", "template file")
 	flag.StringVar(&limitsfile, "l", "", limitsDocumentation)
+	flag.Float64Var(&sizeFactor, "size", 0.00001, sizeFactorDocumentation)
 	flag.StringVar(&seed, "seed", "", seedDocumentation)
 	flag.StringVar(&outputfile, "o", "", outputDocumentation)
 	flag.IntVar(&numOutputs, "n", 1, numOutputDocumentation)
@@ -93,6 +99,7 @@ func main() {
 	check(generate(
 		templatefile, rng,
 		outputfile, limitsfile,
+		sizeFactor,
 		numOutputs, formatted))
 }
 
@@ -100,6 +107,7 @@ func generate(
 	templatefile string,
 	rng *rand.Rand,
 	outputfile, limitsfile string,
+	sizeFactor float64,
 	numOutputs int,
 	formatted bool,
 ) error {
@@ -123,7 +131,7 @@ func generate(
 		}
 	}
 
-	generator := fakedoc.NewGenerator(templ, limits, rng)
+	generator := fakedoc.NewGenerator(templ, limits, sizeFactor, rng)
 
 	if numOutputs == 1 {
 		return generateToFile(generator, outputfile, formatted)

--- a/pkg/fakedoc/template.go
+++ b/pkg/fakedoc/template.go
@@ -72,7 +72,7 @@ type TmplNode interface {
 	AsMap() map[string]any
 
 	// Instantiate creates an instance from this template node.
-	Instantiate(gen *Generator, depth int) (any, error)
+	Instantiate(gen *Generator, limits *LimitNode, depth int) (any, error)
 }
 
 // nodeFactories holds a map of node factories.
@@ -186,8 +186,8 @@ func (t *TmplObject) FromToml(md toml.MetaData, primType toml.Primitive) error {
 }
 
 // Instantiate implements TmplNode
-func (t *TmplObject) Instantiate(gen *Generator, depth int) (any, error) {
-	return gen.generateObject(t, depth)
+func (t *TmplObject) Instantiate(gen *Generator, limits *LimitNode, depth int) (any, error) {
+	return gen.generateObject(t, limits, depth)
 }
 
 // TmplArray describes a JSON array
@@ -222,8 +222,8 @@ func (t *TmplArray) AsMap() map[string]any {
 }
 
 // Instantiate implements TmplNode
-func (t *TmplArray) Instantiate(gen *Generator, depth int) (any, error) {
-	return gen.randomArray(t, depth)
+func (t *TmplArray) Instantiate(gen *Generator, limits *LimitNode, depth int) (any, error) {
+	return gen.randomArray(t, limits, depth)
 }
 
 // TmplOneOf describes the choice between multiple types
@@ -241,8 +241,8 @@ func (t *TmplOneOf) AsMap() map[string]any {
 }
 
 // Instantiate implements TmplNode
-func (t *TmplOneOf) Instantiate(gen *Generator, depth int) (any, error) {
-	return gen.randomOneOf(t.OneOf, depth)
+func (t *TmplOneOf) Instantiate(gen *Generator, limits *LimitNode, depth int) (any, error) {
+	return gen.randomOneOf(t.OneOf, limits, depth)
 }
 
 // TmplString describes how to generate strings
@@ -280,7 +280,7 @@ func (t *TmplString) AsMap() map[string]any {
 }
 
 // Instantiate implements TmplNode
-func (t *TmplString) Instantiate(gen *Generator, _ int) (any, error) {
+func (t *TmplString) Instantiate(gen *Generator, _ *LimitNode, _ int) (any, error) {
 	if len(t.Enum) > 0 {
 		return choose(gen.Rand, t.Enum), nil
 	}
@@ -341,7 +341,7 @@ func (t *TmplLorem) AsMap() map[string]any {
 }
 
 // Instantiate implements TmplNode
-func (t *TmplLorem) Instantiate(gen *Generator, _ int) (any, error) {
+func (t *TmplLorem) Instantiate(gen *Generator, _ *LimitNode, _ int) (any, error) {
 	return gen.loremIpsum(t.MinLength, t.MaxLength, t.Unit), nil
 }
 
@@ -363,7 +363,7 @@ func (t *TmplBook) AsMap() map[string]any {
 }
 
 // Instantiate implements TmplNode
-func (t *TmplBook) Instantiate(gen *Generator, _ int) (any, error) {
+func (t *TmplBook) Instantiate(gen *Generator, _ *LimitNode, _ int) (any, error) {
 	return gen.book(t.MinLength, t.MaxLength, t.Path)
 }
 
@@ -383,7 +383,7 @@ func (t *TmplID) AsMap() map[string]any {
 }
 
 // Instantiate implements TmplNode
-func (t *TmplID) Instantiate(gen *Generator, _ int) (any, error) {
+func (t *TmplID) Instantiate(gen *Generator, _ *LimitNode, _ int) (any, error) {
 	return gen.generateID(t.Namespace), nil
 }
 
@@ -403,7 +403,7 @@ func (t *TmplRef) AsMap() map[string]any {
 }
 
 // Instantiate implements TmplNode
-func (t *TmplRef) Instantiate(gen *Generator, _ int) (any, error) {
+func (t *TmplRef) Instantiate(gen *Generator, _ *LimitNode, _ int) (any, error) {
 	return gen.generateReference(t.Namespace)
 }
 
@@ -431,7 +431,7 @@ func (t *TmplNumber) AsMap() map[string]any {
 }
 
 // Instantiate implements TmplNode
-func (t *TmplNumber) Instantiate(gen *Generator, _ int) (any, error) {
+func (t *TmplNumber) Instantiate(gen *Generator, _ *LimitNode, _ int) (any, error) {
 	return gen.randomNumber(t.Minimum, t.Maximum), nil
 }
 
@@ -459,7 +459,7 @@ func (t *TmplDateTime) AsMap() map[string]any {
 }
 
 // Instantiate implements TmplNode
-func (t *TmplDateTime) Instantiate(gen *Generator, _ int) (any, error) {
+func (t *TmplDateTime) Instantiate(gen *Generator, _ *LimitNode, _ int) (any, error) {
 	return gen.randomDateTime(t.Minimum, t.Maximum), nil
 }
 


### PR DESCRIPTION
The array lengths loaded from `limits.json` are now used as the maximum length when generating arrays. This influence by the `--size` and `--force-max-size` options as briefly described in `README.md`
