### PR TITLE
Replace gob encoding with own writing to hash.

### DIFF
--- a/pkg/fakedoc/generator.go
+++ b/pkg/fakedoc/generator.go
@@ -235,7 +235,7 @@ var sortPool = sync.Pool{
 func hashing(v any, h hash.Hash64) {
 	switch x := v.(type) {
 	case string:
-		h.Write([]byte(x))
+		io.WriteString(h, x)
 	case []any:
 		binary.Write(h, binary.NativeEndian, int32(len(x)))
 		for _, y := range x {
@@ -246,11 +246,11 @@ func hashing(v any, h hash.Hash64) {
 			h.Write(data)
 		}
 	case *reference:
-		h.Write([]byte(x.Namespace))
+		io.WriteString(h, x.Namespace)
 		binary.Write(h, binary.NativeEndian, int32(x.Length))
 		binary.Write(h, binary.NativeEndian, int32(len(x.Values)))
 		for _, y := range x.Values {
-			h.Write([]byte(y))
+			io.WriteString(h, y)
 		}
 	case map[string]any:
 		binary.Write(h, binary.NativeEndian, int32(len(x)))
@@ -260,7 +260,7 @@ func hashing(v any, h hash.Hash64) {
 		}
 		slices.Sort(keys)
 		for _, key := range keys {
-			h.Write([]byte(key))
+			io.WriteString(h, key)
 			hashing(x[key], h)
 		}
 		clear(keys)

--- a/pkg/fakedoc/generator.go
+++ b/pkg/fakedoc/generator.go
@@ -230,6 +230,8 @@ func writeInt32(v int32, h hash.Hash64) {
 	h.Write(buf[:])
 }
 
+// hashing is used to create a 64 bit hash value for
+// a generated item to speed up unique checks.
 func hashing(v any, h hash.Hash64) {
 	switch x := v.(type) {
 	case string:
@@ -252,6 +254,7 @@ func hashing(v any, h hash.Hash64) {
 		}
 	case map[string]any:
 		writeInt32(int32(len(x)), h)
+		// keys := slices.Sorted(maps.Keys(x)) is slower!
 		keys := make([]string, 0, len(x))
 		for key := range x {
 			keys = append(keys, key)


### PR DESCRIPTION
As we already do a recursive re-coding to make gob usable instead 
we can directly write  to the hash during the recursion.

This makes a difference. On my machine:

`main` branch using gob:

``` shell
> /usr/bin/time -f '%E' ./fakedoc \
   -o large.json -size 0.001  -l ../../limits.json \
   -seed pcg:81c43e3f5d1b81f2:8cc495feb113a405
0:29.03
```

This branch using direct hashing:

``` shell
> /usr/bin/time -f '%E' ./fakedoc \
   -o large.json -size 0.001  -l ../../limits.json \
   -seed pcg:81c43e3f5d1b81f2:8cc495feb113a405
0:22.21
```




