### PR TITLE
Add support for profile builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,26 +16,40 @@ and test implementations of this standard.
 
 Will use the CSAF Go library where appropriate.
 
+## Build
+
+``` shell
+go build -o fakedoc ./cmd/fakedoc
+go build -o createtemplate ./cmd/createtemplate
+```
+
+To enable support for profiling with `go tool pprof`
+to fakedoc add the build tag `profile`:
+
+``` shell
+go build -tags profile -o fakedoc ./cmd/fakedoc
+```
+
 ## Usage
 
 Generate a random CSAF document with default settings (with the `-o`
 option for the output file, the tracking ID will match the filename):
 
 ``` shell
-go run cmd/fakedoc/main.go -o random-csaf.json
+./fakedoc -o random-csaf.json
 ```
 
 The generator can be influenced with a template. Create a template
 containing all of the settings used by fakedoc with
 
 ``` shell
-go run cmd/createtemplate/main.go  > template.toml
+./createtemplate > template.toml
 ```
 
 Use the template to generate a document:
 
 ``` shell
-go run cmd/fakedoc/main.go --template template.toml -o random-csaf.json
+./fakedoc --template template.toml -o random-csaf.json
 ```
 
 The template file is used in addition to the built-in template used when
@@ -48,13 +62,13 @@ filename with a template for filenames. This will generate 100 documents
 named `csaf-0.json` through `csaf-99.json`:
 
 ``` shell
-go run cmd/fakedoc/main.go --template template.toml -n 100 -o 'csaf-{{$}}.json'
+./fakedoc --template template.toml -n 100 -o 'csaf-{{$}}.json'
 ```
 
 To generate large documents, one can use the something like this:
 
 ``` shell
-go run cmd/fakedoc/main.go -o random-csaf.json -l limits.json --force-max-size
+./fakedoc -o random-csaf.json -l limits.json --force-max-size
 ```
 
 With the `-l limits.json` option, fakedoc loads information about the
@@ -66,8 +80,7 @@ factor can be set with the `--size` option. With the `--force-max-size`
 option, fakedoc tries to make arrays as large as their maximum length.
 
 How big the files will actually be depends not only on the length of the
-arrays but also on which parts of the document are actually generated. 
-
+arrays but also on which parts of the document are actually generated.
 
 ## License
 

--- a/cmd/fakedoc/main.go
+++ b/cmd/fakedoc/main.go
@@ -88,26 +88,24 @@ func main() {
 	flag.StringVar(&outputfile, "o", "", outputDocumentation)
 	flag.IntVar(&numOutputs, "n", 1, numOutputDocumentation)
 	flag.BoolVar(&formatted, "f", false, formattedDocumentation)
+	// Only used when compiled with 'profile' tag.
+	pf := addProfileFlags()
 	flag.Parse()
 
 	if numOutputs > 1 && outputfile == "" {
 		log.Fatal("Multiple outputs require an explicit output file template")
 	}
 
-	var (
-		rng *rand.Rand
-		err error
-	)
-	if seed != "" {
-		rng, err = fakedoc.ParseSeed(seed)
-		check(err)
-	}
+	rng, err := fakedoc.ParseSeed(seed)
+	check(err)
 
-	check(generate(
-		templatefile, rng,
-		outputfile, limitsfile,
-		sizeFactor, forceMaxSize,
-		numOutputs, formatted))
+	check(pf.profile(func() error {
+		return generate(
+			templatefile, rng,
+			outputfile, limitsfile,
+			sizeFactor, forceMaxSize,
+			numOutputs, formatted)
+	}))
 }
 
 func generate(

--- a/cmd/fakedoc/no_profile.go
+++ b/cmd/fakedoc/no_profile.go
@@ -1,0 +1,24 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2024 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2024 Intevation GmbH <https://intevation.de>
+
+//go:build !profile
+
+package main
+
+// profileFlags is empty.
+type profileFlags struct{}
+
+// addProfileFlags does nothing and returns nil.
+func addProfileFlags() *profileFlags {
+	return nil
+}
+
+// profile only calls fn and returns its return value.
+func (*profileFlags) profile(fn func() error) error {
+	return fn()
+}

--- a/cmd/fakedoc/profile.go
+++ b/cmd/fakedoc/profile.go
@@ -1,0 +1,71 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2024 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2024 Intevation GmbH <https://intevation.de>
+
+//go:build profile
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"os"
+	"runtime"
+	"runtime/pprof"
+)
+
+const (
+	cpuProfileDocumentation = `
+Name of the profile file. If empty (default) no profile file is written.
+`
+	memProfileDocumentation = `
+Name of the memory profile file. If empty (default) no memory profile file is written.
+`
+)
+
+type profileFlags struct {
+	// cpuProfile is the file name of the cpu profile.
+	cpuProfile string
+	// memProfile is the file name of the memory profile.
+	memProfile string
+}
+
+// addProfileFlags adds flags for the profiler to the command line parser.
+func addProfileFlags() *profileFlags {
+	pf := profileFlags{}
+	flag.StringVar(&pf.cpuProfile, "cpuprofile", "", cpuProfileDocumentation)
+	flag.StringVar(&pf.memProfile, "memprofile", "", memProfileDocumentation)
+	return &pf
+}
+
+// profile create cpu and/or mery profile files for the given function.
+func (pf *profileFlags) profile(fn func() error) error {
+	if pf.cpuProfile != "" {
+		f, err := os.Create(pf.cpuProfile)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		if err := pprof.StartCPUProfile(f); err != nil {
+			return err
+		}
+		defer pprof.StopCPUProfile()
+	}
+	ret := fn()
+	if pf.memProfile != "" {
+		f, err := os.Create(pf.memProfile)
+		if err != nil {
+			return errors.Join(ret, err)
+		}
+		defer f.Close()
+		runtime.GC() // get up-to-date statistics.
+		if err := pprof.WriteHeapProfile(f); err != nil {
+			return errors.Join(ret, err)
+		}
+	}
+	return ret
+}

--- a/pkg/fakedoc/random.go
+++ b/pkg/fakedoc/random.go
@@ -50,8 +50,12 @@ var ErrSeedFormat = errors.New(
 var seedPattern = regexp.MustCompile("^pcg:([0-9a-fA-F]{1,16}):([0-9a-fA-F]{1,16})$")
 
 // ParseSeed parses a seed from a string and returns the resulting
-// random number generator
+// random number generator.
+// If the seed string is empty nil is returned.
 func ParseSeed(seed string) (*rand.Rand, error) {
+	if seed == "" {
+		return nil, nil
+	}
 	matches := seedPattern.FindStringSubmatch(seed)
 	if matches == nil {
 		return nil, ErrSeedFormat


### PR DESCRIPTION
Compiled with the build tag `profile` adds commandline options to write cpu and/memory profile files.