### PR TITLE
Handle corner cases of lengths in Generator.book

### DIFF
--- a/pkg/fakedoc/generator.go
+++ b/pkg/fakedoc/generator.go
@@ -607,8 +607,11 @@ func (gen *Generator) book(minlength, maxlength int, path string, limits *LimitN
 			maxlength = int(float64(maxlength) * gen.SizeFactor)
 		}
 	}
+	if maxlength < minlength {
+		maxlength = minlength
+	}
 
-	length := minlength + gen.Rand.IntN(maxlength-minlength)
+	length := minlength + gen.Rand.IntN(maxlength-minlength+1)
 	content, ok := gen.FileCache[path]
 	if !ok {
 		file, err := os.Open(path)


### PR DESCRIPTION
In particular, if minlength is given in the template and maxlength is taken from the limit file, maxlength may be less than minlength. In that case we now make maxlength equal to minlength.

Also, the argument of IntN must be maxlength-minlength+1 so that maxlength is actually a value that might be generated. This will also handle the case of maxlength == minlength correctly and without a panic.