### PR TITLE
Implement a --verbose flag

### DIFF
--- a/cmd/fakedoc/main.go
+++ b/cmd/fakedoc/main.go
@@ -45,6 +45,7 @@ type Options struct {
 	NumOutputs   int     `long:"num-outputs" short:"n" default:"1" description:"How many documents to generate . If greater than 1, the output filename must be given. It is treated as a template for filenames in which {{$}} will be replaced with the number of the file, starting with 0."`
 	Formatted    bool    `long:"format" short:"f" description:"Output JSON should be formatted."`
 	RequireRegex string  `long:"require" description:"Specifies with a regular expression what fields to force as required."`
+	Verbose      bool    `long:"verbose" short:"v" description:"Verbose output"`
 }
 
 func main() {
@@ -80,7 +81,7 @@ func main() {
 			opts.OutputFile, opts.LimitsFile,
 			opts.SizeFactor, opts.ForceMaxSize,
 			opts.NumOutputs, opts.Formatted,
-			opts.RequireRegex)
+			opts.RequireRegex, opts.Verbose)
 	}))
 }
 
@@ -92,6 +93,7 @@ func generate(
 	numOutputs int,
 	formatted bool,
 	requireFlag string,
+	verbose bool,
 ) error {
 	templ, err := fakedoc.FromCSAFSchema()
 	if err != nil {
@@ -99,6 +101,9 @@ func generate(
 	}
 
 	if templatefile != "" {
+		if verbose {
+			fmt.Printf("Loading template %q\n", templatefile)
+		}
 		overrides, err := fakedoc.LoadTemplate(templatefile)
 		if err != nil {
 			return err
@@ -108,6 +113,9 @@ func generate(
 
 	var limits *fakedoc.Limits
 	if limitsfile != "" {
+		if verbose {
+			fmt.Printf("Loading limits %q\n", limitsfile)
+		}
 		if limits, err = fakedoc.LoadLimitsFromFile(limitsfile); err != nil {
 			return err
 		}
@@ -121,7 +129,7 @@ func generate(
 	}
 
 	generator := fakedoc.NewGenerator(
-		templ, limits, sizeFactor, forceMaxSize, rng, requireRegex)
+		templ, limits, sizeFactor, forceMaxSize, rng, requireRegex, verbose)
 
 	if numOutputs == 1 {
 		return generateToFile(generator, outputfile, formatted)
@@ -143,6 +151,7 @@ func generate(
 			return err
 		}
 	}
+	generator.Verbosef("\n")
 
 	return nil
 }
@@ -162,6 +171,9 @@ func generateToFile(
 	outputfile string,
 	formatted bool,
 ) error {
+	if outputfile != "" {
+		generator.Verbosef("generating %q", outputfile)
+	}
 	csaf, err := generator.Generate()
 	if err != nil {
 		return err

--- a/cmd/fakedoc/main.go
+++ b/cmd/fakedoc/main.go
@@ -132,7 +132,11 @@ func generate(
 		templ, limits, sizeFactor, forceMaxSize, rng, requireRegex, verbose)
 
 	if numOutputs == 1 {
-		return generateToFile(generator, outputfile, formatted)
+		err := generateToFile(generator, outputfile, formatted)
+		if outputfile != "" {
+			generator.Verbosef("\n")
+		}
+		return err
 	}
 
 	tmplFilename, err := template.New("filename").Parse(outputfile)

--- a/pkg/fakedoc/generator.go
+++ b/pkg/fakedoc/generator.go
@@ -625,7 +625,7 @@ func (gen *Generator) book(minlength, maxlength int, path string, limits *LimitN
 	length := minlength + gen.Rand.IntN(maxlength-minlength+1)
 	content, ok := gen.FileCache[path]
 	if !ok {
-		gen.Verbosef("Loading book %q\n", path)
+		gen.Verbosef("\nLoading book %q\n", path)
 		file, err := os.Open(path)
 		if err != nil {
 			return "", err

--- a/pkg/fakedoc/generator.go
+++ b/pkg/fakedoc/generator.go
@@ -63,6 +63,7 @@ type Generator struct {
 	SizeFactor      float64
 	ForceMaxSize    bool
 	RequireRegex    *regexp.Regexp
+	Verbose         bool
 	Rand            *rand.Rand
 	FileCache       map[string]string
 	NameSpaces      map[string]*NameSpace
@@ -186,6 +187,7 @@ func NewGenerator(
 	forceMaxSize bool,
 	rng *rand.Rand,
 	requireRegex *regexp.Regexp,
+	verbose bool,
 ) *Generator {
 	if rng == nil {
 		seed1, seed2 := rand.Uint64(), rand.Uint64()
@@ -199,9 +201,18 @@ func NewGenerator(
 		ForceMaxSize:    forceMaxSize,
 		Rand:            rng,
 		RequireRegex:    requireRegex,
+		Verbose:         verbose,
 		FileCache:       map[string]string{},
 		NameSpaces:      map[string]*NameSpace{},
 		namespaceIDErrs: map[string]error{},
+	}
+}
+
+// Verbosef prints a message to stdout if the verbose flag is true. The
+// parameters are passed through to fmt.Printf.
+func (gen *Generator) Verbosef(format string, a ...any) {
+	if gen.Verbose {
+		fmt.Printf(format, a...)
 	}
 }
 
@@ -614,6 +625,7 @@ func (gen *Generator) book(minlength, maxlength int, path string, limits *LimitN
 	length := minlength + gen.Rand.IntN(maxlength-minlength+1)
 	content, ok := gen.FileCache[path]
 	if !ok {
+		gen.Verbosef("Loading book %q\n", path)
 		file, err := os.Open(path)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
When fakedoc is invoked with the --verbose flag, some additional information is printed to stdout:

 - Which files are being generated

 - Which files are read: which template, files read for book elements

The interaction with other outputs, like the [n/m] progress indicator or printing the random number generator seed is not optimal, but it's also not so clear, just how they should interact.